### PR TITLE
Add variable to remove deprecation error on PHP 8.2

### DIFF
--- a/inc/SageVariableData.php
+++ b/inc/SageVariableData.php
@@ -21,6 +21,8 @@ class SageVariableData
     public $extendedValue;
     /** @var string short inline value */
     public $value;
+    /** @var bool */
+    public $alreadyEscaped;
 
     /** @var array extra views of the same variable data used in rich view. Keys are tab names, values is content */
     private $alternativeRepresentations = array();


### PR DESCRIPTION
Fix deprecation error on PHP 8.2

`[ Deprecated error ] Creation of dynamic property SageVariableData::$alreadyEscaped is deprecated ~ ROOT/vendor/php-sage/sage/inc/SageParser.php:280`